### PR TITLE
add auth flow to get github email

### DIFF
--- a/github-email.sh
+++ b/github-email.sh
@@ -30,8 +30,15 @@ repo="$2"
 
 
 header 'Email on GitHub'
-curl "https://api.github.com/users/$user" -s \
-    | sed -nE 's#^.*"email": "([^"]+)",.*$#\1#p'
+if [ -z $GH_EMAIL_TOKEN ]; then
+    fade "   Github requires authenticated API requests to retrieve the email. See: https://git.io/vxctz"
+    fade "   To enable, open https://github.com/settings/tokens/new?description=github-email …"
+    fade "   Keep the checkboxes unchecked, hit 'Generate token', copy the token, then run this in your shell:"
+    fade "       export GH_EMAIL_TOKEN=<token>"
+else
+    curl "https://api.github.com/users/$user?access_token=$GH_EMAIL_TOKEN" -s \
+        | sed -nE 's#^.*"email": "([^"]+)",.*$#\1#p'
+fi
 
 header 'Email on npm'
 if hash jq 2>/dev/null; then


### PR DESCRIPTION
@fpg1503 what do you think about this:


now when running you see this:

![untitled-2 fw](https://user-images.githubusercontent.com/39191/37691349-7afc5f0e-2c6e-11e8-9e70-343bf1567a95.png)

and after following instructions..

![untitled-3 fw](https://user-images.githubusercontent.com/39191/37691347-7620e0ea-2c6e-11e8-9a9e-92b67d43e5b2.png) 


The text:

> Github requires authenticated API requests to retrieve the email. See: https://git.io/vxctz
> To enable, open https://github.com/settings/tokens/new?description=github-email …
> Keep the checkboxes unchecked, hit 'Generate token', copy the token, then run this in your shell:
>     `export GH_EMAIL_TOKEN=<token>`


wdyt?
fixes #7 